### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -128,6 +128,8 @@ jobs:
       - build_agents
     if: needs.extract_main_version.outputs.version != ''
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: ⬇️ Download all build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Potential fix for [https://github.com/YangYang-Research/whale-sentinel-agents/security/code-scanning/11](https://github.com/YangYang-Research/whale-sentinel-agents/security/code-scanning/11)

To fix the issue, we will add a `permissions` block to the `create_release` job. This block will explicitly define the minimal permissions required for the job to function correctly. Specifically, the `create_release` job needs `contents: write` to create a release and upload artifacts. Adding this block ensures that the `GITHUB_TOKEN` has only the necessary permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
